### PR TITLE
Removes the explicit style import for a @import css declaration

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css?family=Lato');
+
 *{
   color: #FFF;
   padding: 0;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <title>Last Man Standing</title>
-    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <script type="text/javascript" src="js/index.js"></script>
   </head>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/@import#Browser_compatibility

`@import` is a way of referencing external style sheets. It can help co-locate dependent style sheets, even if it produces a waterfall-like cascade of requests, unless your site is highly optimised, this will not be an issue.
